### PR TITLE
changed reties to retries

### DIFF
--- a/code/roles/attach_device_template/tasks/wait_until_completed.yml
+++ b/code/roles/attach_device_template/tasks/wait_until_completed.yml
@@ -10,7 +10,7 @@
       Content-Type: "application/json"
   register: state
   until: "state.json.data[0].status != 'In progress'"
-  reties: 5
+  retries: 5
   delay: 10
 
 - debug:


### PR DESCRIPTION
Corrected error in wait_until_completed.yml file.  Changed reties to retries.
Running the playbook failed with this error present.